### PR TITLE
Update to chat-miner 0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 altair==5.1.2
 calmap==0.0.9
-chat-miner==0.5.0
+chat-miner==0.6.0
 numpy==1.24.2
 pandas==1.5.3
 scikit-learn==1.2.1


### PR DESCRIPTION
Chat miner 0.5 kept crashing if the message contained ':' or was a multi line message as it expected every line to be a single message and of the form Date:Author:Message, so updated to 0.6 with required changes.

Added a column is_media for chat exports without media.

Added another value for deleted message list as the deleted message in latest english version of chat exports are "This message was deleted" and there is no period.